### PR TITLE
Add travis support for googlapis/openapis-compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+
+language: go
+
+script: go build -v ./...
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/googleapis/openapi-compiler.svg?branch=master)](https://travis-ci.org/googleapis/openapi-compiler)
+
 # OpenAPI Compiler
 
 This repository contains an experimental project whose goal is to


### PR DESCRIPTION
Currently this change only does build of all the code. We need to add 'go test' too into travis script.
For some reason i was getting weird errors when doing go test -v ./...
