### PR TITLE
Update Stencil to an official tagged version [Swift]

### DIFF
--- a/plugins/swift/openapi_swift_generator/Package.swift
+++ b/plugins/swift/openapi_swift_generator/Package.swift
@@ -25,6 +25,6 @@ let package = Package(
   ],
   dependencies: [
     .Package(url: "https://github.com/apple/swift-protobuf.git", Version(0,9,24)),
-    .Package(url: "https://github.com/timburks/Stencil.git", Version(9,9,9)) // temporary fork
+    .Package(url: "https://github.com/kylef/Stencil.git", Version(0,8,0))
   ]
 )


### PR DESCRIPTION
Resolves [this issue](https://github.com/googleapis/openapi-compiler/issues/26).